### PR TITLE
Fix tendency to move in a straight line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,7 +322,7 @@ dependencies = [
  "compact_str",
  "crossterm",
  "indoc",
- "itertools",
+ "itertools 0.12.1",
  "lru",
  "paste",
  "stability",
@@ -441,6 +450,7 @@ name = "snake-tui"
 version = "0.1.0"
 dependencies = [
  "crossterm",
+ "itertools 0.13.0",
  "rand",
  "ratatui",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 crossterm = "0.27.0"
+itertools = "0.13.0"
 rand = "0.8.5"
 ratatui = "0.26.2"
 rayon = "1.10.0"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,6 +1,7 @@
 //! AI Agent
 //! An instance of the Game played by an AI
 
+use itertools::Itertools;
 use nn::Net;
 
 use crate::game::Game;
@@ -74,27 +75,31 @@ impl Agent {
         let vision = self.get_brain_input();
         let cur_dir = self.game.dir;
         let nn_out = self.brain.predict(vision).last().unwrap().clone();
-        let max_index = nn_out
+        let mut max_indexes = nn_out
             .iter()
             .enumerate()
-            .max_by(|(_, &a), (_, &b)| a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal))
-            .map(|(i, _)| i)
-            .unwrap();
-        let dir = match max_index {
-            0 => FourDirs::Left,
-            1 => FourDirs::Right,
-            2 => FourDirs::Bottom,
+            .sorted_by(|(_, &a), (_, &b)| a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(i, _)| i);
+        let dir = match max_indexes.next() {
+            Some(0) => FourDirs::Left,
+            Some(1) => FourDirs::Right,
+            Some(2) => FourDirs::Bottom,
             _ => FourDirs::Top,
         };
 
-        // Prevent the snake from turning back on itself
-        if (cur_dir.is_horizontal() && dir.is_horizontal())
-            || (cur_dir.is_vertical() && dir.is_vertical())
-        {
-            if cur_dir != dir {
-                cur_dir
-            } else {
-                dir
+        if matches!(
+            (cur_dir, dir),
+            (FourDirs::Left, FourDirs::Right)
+                | (FourDirs::Right, FourDirs::Left)
+                | (FourDirs::Top, FourDirs::Bottom)
+                | (FourDirs::Bottom, FourDirs::Top)
+        ) {
+            // Prevent the snake from turning back on itself by choosing the second highest output
+            match max_indexes.next() {
+                Some(0) => FourDirs::Left,
+                Some(1) => FourDirs::Right,
+                Some(2) => FourDirs::Bottom,
+                _ => FourDirs::Top,
             }
         } else {
             dir

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -40,7 +40,7 @@ impl Simulation {
 
     pub fn update(&mut self) {
         let games_alive = self.pop.update();
-        if games_alive <= 0 {
+        if games_alive == 0 {
             self.end_current_genration();
             self.start_new_generation();
         }


### PR DESCRIPTION
The second highest output is now chosen if the snake would turn back on
itself instead of the highest output. This should prevent the snake from
moving in a straight line for too long.
